### PR TITLE
Specify lib version

### DIFF
--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -1,0 +1,17 @@
+name: check
+
+on:
+  pull_request:
+    paths:
+    - Dockerfile
+
+jobs:
+  hadolint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: hadolint
+      uses: burdzwastaken/hadolint-action@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        HADOLINT_ACTION_DOCKERFILE_FOLDER: .

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -3,7 +3,8 @@ name: check
 on:
   pull_request:
     paths:
-    - Dockerfile
+      - Dockerfile
+      - .github/workflows/hadolint.yml
 
 jobs:
   hadolint:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ RUN apt-get update > /dev/null && apt-get install -y --reinstall build-essential
     file \
     git \
     default-libmysqlclient-dev \
-    mecab \
+    mecab=0.996-1.1 \
+    libmecab-dev=0.996-1.1 \
     mecab-ipadic-utf8 \
     libmecab-dev \
     swig

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ RUN apt-get update > /dev/null && apt-get install -y --reinstall build-essential
     git \
     default-libmysqlclient-dev \
     mecab=0.996-1.1 \
-    libmecab-dev=0.996-1.1 \
     mecab-ipadic-utf8 \
-    libmecab-dev \
+    libmecab-dev=0.996-1.1 \
     swig

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 FROM python:3.5-slim-stretch
-RUN apt-get update > /dev/null && apt-get install -y --reinstall build-essential && \
-    apt-get install -y --no-install-recommends \
-    curl \
-    file \
-    git \
-    default-libmysqlclient-dev \
-    mecab=0.996-1.1 \
-    mecab-ipadic-utf8 \
-    libmecab-dev=0.996-1.1 \
-    swig
+RUN apt-get update > /dev/null && apt-get install -y --no-install-recommends \
+    build-essential=12.3 \
+    curl=7.52.1-5+deb9u11 \
+    file=1:5.30-1+deb9u3 \
+    git=1:2.11.0-3+deb9u7 \
+    default-libmysqlclient-dev=1.0.2 \
+    mecab=0.996-3.1 \
+    mecab-ipadic-utf8=2.7.0-20070801+main-1 \
+    libmecab-dev=0.996-3.1 \
+    swig=3.0.10-1.1 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
# why
To fix the mecab version

# what
- Specify the latest version based on the versions installed in the last build
- Add `hadolint`

# reference

- https://taku910.github.io/mecab/
- https://github.com/IntimateMerger/dockerfile-mecab-python/blob/master/Dockerfile
- https://hub.docker.com/repository/registry-1.docker.io/bebit/python-mecab-builder/builds/2b16036d-56bf-49f4-a484-5b696c901b78

# version

```
E: Version '0.996-1.1' for 'mecab' was not found
E: Version '2.7.0-20070801+main-2.1' for 'mecab-ipadic-utf8' was not found
E: Version '0.996-1.1' for 'libmecab-dev' was not found
```