### PR TITLE
Update python version from 3.5-slim-stretch to 3.7-slim-stretch (#3)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5-slim-stretch
+FROM python:3.7-slim-stretch
 RUN apt-get update > /dev/null && apt-get install -y --no-install-recommends \
     build-essential=12.3 \
     curl=7.52.1-5+deb9u11 \


### PR DESCRIPTION
## Why
Need to update python version to `3.7.8`

## What
Recently PR [#663](https://github.com/bebit/user-app-server-side/pull/663) was merged to the `master` branch.
But to merge the latest `master` into `django_dx_improvement` branch, we need to update the two base image from python `3.5.6` to `3.7.8`.

## Additional notes

- Will need to create a new release tag before merging this PR - https://github.com/bebit/python-mecab/pull/2