### PR TITLE
Merge 'dev' to 'master' for 'django_dx_improvement' release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5-slim-stretch
+FROM python:3.7-slim-stretch
 RUN apt-get update > /dev/null && apt-get install -y --no-install-recommends \
     build-essential=12.3 \
     curl=7.52.1-5+deb9u11 \


### PR DESCRIPTION
## What
Merge `dev` branch to `master`

## Why
- New changes in `django_dx_improvement` uses python `3.7`
- Prepare for release as part of `django_dx_improvement`

## Ticket
[UG-6060](https://bebit-sw.atlassian.net/browse/UG-6060)

## References
https://bebit.slack.com/archives/CRZRZ67S9/p1599006497169000
