### PR TITLE
UK-11077: Update Debian to bluster and update package minor version for the new OS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM python:3.7-slim-stretch
+FROM python:3.7-slim-buster
 RUN apt-get update > /dev/null && apt-get install -y --no-install-recommends \
-    build-essential=12.3 \
-    curl=7.52.1-5+deb9u11 \
-    file=1:5.30-1+deb9u3 \
-    git=1:2.11.0-3+deb9u7 \
-    default-libmysqlclient-dev=1.0.2 \
-    mecab=0.996-3.1 \
-    mecab-ipadic-utf8=2.7.0-20070801+main-1 \
-    libmecab-dev=0.996-3.1 \
-    swig=3.0.10-1.1 \
+    build-essential=12.6 \
+    curl=7.64.0-4+deb10u2 \
+    file=1:5.35-4+deb10u2 \
+    git=1:2.20.1-2+deb10u3 \
+    default-libmysqlclient-dev=1.0.5 \
+    mecab=0.996-6 \
+    mecab-ipadic-utf8=2.7.0-20070801+main-2.1 \
+    libmecab-dev=0.996-6 \
+    swig=3.0.12-2 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
# Why
- Debian 9 (stretch) python image is no longer supported and contains a lot of Vulnerability Issues

# What
- Upgrade python 3.7 image to Debian 10 - Bluster. https://github.com/docker-library/python/tree/master/3.7
- Upgrade apt-packages versions to the one supported in Debian 10.

# Reference
https://packages.debian.org/buster/build-essential
https://packages.debian.org/buster/curl
https://packages.debian.org/buster/file
https://packages.debian.org/buster/git
https://packages.debian.org/buster/default-libmysqlclient-dev
https://packages.debian.org/buster/mecab
https://packages.debian.org/buster/mecab-ipadic-utf8
https://packages.debian.org/buster/libmecab-dev
https://packages.debian.org/buster/swig
