### PR TITLE
UK-12846: use python:3.10-slim-buster as base image

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          version: v0.10.2
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - Dockerfile
+      - .github/workflows/build-and-push.yml
     types:
       - opened # default
       - synchronize # default
@@ -26,8 +27,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -35,14 +39,15 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v4
         with:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim-buster
+FROM python:3.10-slim-buster
 RUN apt-get update > /dev/null && apt-get install -y --no-install-recommends \
     build-essential=12.6 \
     curl=7.64.0-4+deb10u3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.10-slim-buster
 RUN apt-get update > /dev/null && apt-get install -y --no-install-recommends \
     build-essential=12.6 \
-    curl=7.64.0-4+deb10u3 \
+    curl=7.64.0-4+deb10u4 \
     file=1:5.35-4+deb10u2 \
     git=1:2.20.1-2+deb10u3 \
     default-libmysqlclient-dev=1.0.5 \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # python-mecab-builder
 
-`Python 3.7` with `mecab` builder dependencies.
+`Python 3.10` with `mecab` builder dependencies.
 
 ## How to use
 - Until 2.0 release, docker images are stored in https://hub.docker.com/r/bebit/python-mecab-builder


### PR DESCRIPTION
# Why
Upgrade to python 3.10
# What 
use python:3.10-slim-buster as base image
# When
Anytime