### PR TITLE
Support multi-platform build

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - Dockerfile
+      - .github/workflows/build-and-push.yml
     types:
       - opened # default
       - synchronize # default

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -31,7 +31,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -39,12 +39,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v4
         with:
           context: .
           push: true

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
@@ -46,3 +49,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
# Why

To support `linux/arm64` arch for M1 mac
https://bebit.slack.com/archives/C047RE2K4H1/p1675847580482259

# What

update workflow to support `linux/arm64`

- prev build doesn't have `OS / Arch` tab
  - https://github.com/bebit/python-mecab-builder/pkgs/container/python-mecab-builder-dev/67876475?tag=pr-14
- this PR has
   -  https://github.com/bebit/python-mecab-builder/pkgs/container/python-mecab-builder-dev/69018082?tag=pr-15

# How to check in local

```
docker pull ghcr.io/bebit/python-mecab-builder-dev:pr-15
docker image inspect ghcr.io/bebit/python-mecab-builder-dev:pr-15 | grep Architecture
```