### PR TITLE
Uk 16847 update with bookworm-debian and includes ipadic-neologd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,21 @@
-FROM python:3.10-slim-bookworm
+FROM python:3.10-slim-bookworm as base
 RUN apt-get update > /dev/null && apt-get install -y --no-install-recommends \
     build-essential=12.9 \
     curl=7.88.1-10+deb12u4 \
     file=1:5.44-3 \
     git=1:2.39.2-1.1 \
     default-libmysqlclient-dev=1.1.0 \
-    mecab=0.996-14+b14 \
-    mecab-ipadic-utf8=2.7.0-20070801+main-3 \
-    libmecab-dev=0.996-14+b14 \
-    swig=4.1.0-0.2 \
+    #swig=4.1.0-0.2 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+FROM base as dictionary-builder
+RUN apt-get update > /dev/null && apt-get install -y --no-install-recommends \
+    mecab=0.996-14+b14 \
+    #mecab-ipadic-utf8=2.7.0-20070801+main-3 \
+    libmecab-dev=0.996-14+b14 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+RUN git clone --depth 1 https://github.com/neologd/mecab-ipadic-neologd.git && \
+    mecab-ipadic-neologd/bin/install-mecab-ipadic-neologd -y -n -p /var/lib/mecab/dic/mecab-ipadic-neologd
+FROM base as builder
+COPY --from=dictionary-builder /var/lib/mecab  /var/lib/mecab

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,12 @@ RUN apt-get update > /dev/null && apt-get install -y --no-install-recommends \
     file=1:5.44-3 \
     git=1:2.39.2-1.1 \
     default-libmysqlclient-dev=1.1.0 \
-    #swig=4.1.0-0.2 \
+    swig=4.1.0-0.2 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 FROM base as dictionary-builder
 RUN apt-get update > /dev/null && apt-get install -y --no-install-recommends \
     mecab=0.996-14+b14 \
-    #mecab-ipadic-utf8=2.7.0-20070801+main-3 \
     libmecab-dev=0.996-14+b14 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,17 @@
-FROM python:3.10-slim-bookworm as base
+FROM python:3.10-slim-bookworm as dictionary-builder
 RUN apt-get update > /dev/null && apt-get install -y --no-install-recommends \
     build-essential=12.9 \
-    curl=7.88.1-10+deb12u4 \
+    curl=7.88.1-10+deb12u5 \
     file=1:5.44-3 \
     git=1:2.39.2-1.1 \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-FROM base as dictionary-builder
-RUN apt-get update > /dev/null && apt-get install -y --no-install-recommends \
+    mecab-ipadic-utf8=2.7.0-20070801+main-3 \
     mecab=0.996-14+b14 \
     libmecab-dev=0.996-14+b14 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
 RUN git clone --depth 1 https://github.com/neologd/mecab-ipadic-neologd.git && \
     mecab-ipadic-neologd/bin/install-mecab-ipadic-neologd -y -n -p /var/lib/mecab/dic/mecab-ipadic-neologd
-FROM base as builder
+
+FROM python:3.10-slim-bookworm as mecab
 COPY --from=dictionary-builder /var/lib/mecab  /var/lib/mecab

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM python:3.10-slim-buster
+FROM python:3.10-slim-bookworm
 RUN apt-get update > /dev/null && apt-get install -y --no-install-recommends \
-    build-essential=12.6 \
-    curl=7.64.0-4+deb10u5 \
-    file=1:5.35-4+deb10u2 \
-    git=1:2.20.1-2+deb10u3 \
-    default-libmysqlclient-dev=1.0.5 \
-    mecab=0.996-6 \
-    mecab-ipadic-utf8=2.7.0-20070801+main-2.1 \
-    libmecab-dev=0.996-6 \
-    swig=3.0.12-2 \
+    build-essential=12.9 \
+    curl=7.88.1-10+deb12u4 \
+    file=1:5.44-3 \
+    git=1:2.39.2-1.1 \
+    default-libmysqlclient-dev=1.1.0 \
+    mecab=0.996-14+b14 \
+    mecab-ipadic-utf8=2.7.0-20070801+main-3 \
+    libmecab-dev=0.996-14+b14 \
+    swig=4.1.0-0.2 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ RUN apt-get update > /dev/null && apt-get install -y --no-install-recommends \
     curl=7.88.1-10+deb12u4 \
     file=1:5.44-3 \
     git=1:2.39.2-1.1 \
-    default-libmysqlclient-dev=1.1.0 \
-    swig=4.1.0-0.2 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 FROM base as dictionary-builder


### PR DESCRIPTION
## Why
I need to update python-mecab-builder to decrease vulnerabilities of client-app-server-side.


We have discussed how to user-app-server-side and decided to proceed with the following way.
- Use only python-mecab-builder and 3.10-slim-bookworm image (don’t use python-mecab image)
- Create the dictionary in Dockerfile of Python-mecab-builder
- Some MeCab related Debian package should be removed from new images to avoid duplication.
- Use parameters that specify place of dictionary instead of macabrc 
- MeCab.Tagger("-r/dev/null -d/var/lib/mecab/dic/mecab-ipadic-neologd -Ochasen")
- Upgrade mecab-python3 module from 0.996.x to 1.0.8

## What

Upgrade python-mecab-builder image from Buster to bookworm with latest package in Debian 12(bookworm)
and  Include building ipadic-neologd in this Dockerfile to abolish python-mecab.

### builder
  | current Buster(Debian10) | bookworm(Debian12)
-- | -- | --
build-essential | 12.6 | [12.9](https://packages.debian.org/en/bookworm/build-essential)
curl | 7.64.0-4+deb10u5 | [7.88.1-10+deb12u4](https://packages.debian.org/en/bookworm/curl)
file | 1:5.35-4+deb10u2 | [1:5.44-3](https://packages.debian.org/en/bookworm/file)
git | 1:2.20.1-2+deb10u3 | [1:2.39.2-1.1](https://packages.debian.org/en/bookworm/git)
~default-libmysqlclient-dev~ | 1.0.5 | [1.1.0](https://packages.debian.org/en/bookworm/default-libmysqlclient-dev)
~mecab~ | 0.996-6 | [0.996-14+b14](https://packages.debian.org/en/bookworm/mecab)
~mecab-ipadic-utf8~ | 2.7.0-20070801+main-2.1 | [2.7.0-20070801+main-3](https://packages.debian.org/en/bookworm/mecab-ipadic-utf8)
~libmecab-dev~ | 0.996-6 | [0.996-14+b14](https://packages.debian.org/en/bookworm/libmecab-dev)
~swig~ | 3.0.12-2 | [4.1.0-0.2](https://packages.debian.org/en/bookworm/swig)

### dictionary-builder

  | current Buster(Debian10) | bookworm(Debian12)
-- | -- | --
mecab | 0.996-6 | [0.996-14+b14](https://packages.debian.org/en/bookworm/mecab)
libmecab-dev | 0.996-6 | [0.996-14+b14](https://packages.debian.org/en/bookworm/libmecab-dev)

## Steps of confirmation
https://bebit-sw.atlassian.net/wiki/spaces/~778649755/pages/2925690881/Security+Update+python-mecab-builder+to+use+bookworm+Debian

### Result of https://packages.debian.org/search
<details><summary>build-essential 12.9</summary>
<p>

<img width="1440" alt="image" src="https://github.com/bebit/python-mecab-builder/assets/77015768/efc3d99e-d365-4658-ba0b-c1b8ddaf7245">


</p>

</details> 

<details><summary>curl 7.88.1-10+deb12u4</summary>
<p>

<img width="1432" alt="image" src="https://github.com/bebit/python-mecab-builder/assets/77015768/9a1e277d-8a15-4cef-8c69-9633180f1776">

</p>

</details>
<details><summary>file 1:5.44-3</summary>
<p>

<img width="1426" alt="image" src="https://github.com/bebit/python-mecab-builder/assets/77015768/ad24ff75-cf82-4d2a-968e-852664b18e39">

</p>

</details>
<details><summary>git 1:2.39.2-1.1</summary>
<p>

<img width="1419" alt="image" src="https://github.com/bebit/python-mecab-builder/assets/77015768/f9243db5-7342-4689-8501-b2ad747eb9c5">

</p>

</details>
<details><summary>default-libmysqlclient-dev 1.1.0</summary>
<p>

<img width="1439" alt="image" src="https://github.com/bebit/python-mecab-builder/assets/77015768/e25039a0-8cbb-447a-b842-3c2e30e4188a">

</p>

</details>
<details><summary>mecab 0.996-14+b14</summary>
<p>

<img width="1430" alt="image" src="https://github.com/bebit/python-mecab-builder/assets/77015768/995a9d02-610e-4671-97b8-f59ea95abff4">

</p>

</details>
<details><summary>mecab-ipadic-utf8 2.7.0-20070801+main-3</summary>
<p>

<img width="1437" alt="image" src="https://github.com/bebit/python-mecab-builder/assets/77015768/fcca36dd-4dcc-4b8f-8b88-2a74ce38e2e7">

</p>

</details>
<details><summary>libmecab-dev 0.996-14+b14</summary>
<p>

<img width="1434" alt="image" src="https://github.com/bebit/python-mecab-builder/assets/77015768/eb3f9a72-b0fb-4b45-9977-918f30c02a2a">

</p>

</details>
<details><summary>swig 4.1.0-0.2</summary>
<p>

<img width="1440" alt="image" src="https://github.com/bebit/python-mecab-builder/assets/77015768/7b2e8bd9-aea3-4164-a395-ca0bf28e8bf1">

</p>

</details>