### PR TITLE
UK-20532: Upgrade python to 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-buster
+FROM python:3.12-slim-bookworm
 RUN apt-get update > /dev/null && apt-get install -y --no-install-recommends \
     build-essential=12.6 \
     curl=7.64.0-4+deb10u5 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM python:3.12-slim-bookworm
 RUN apt-get update > /dev/null && apt-get install -y --no-install-recommends \
-    build-essential=12.6 \
-    curl=7.64.0-4+deb10u5 \
-    file=1:5.35-4+deb10u2 \
-    git=1:2.20.1-2+deb10u3 \
-    default-libmysqlclient-dev=1.0.5 \
-    mecab=0.996-6 \
-    mecab-ipadic-utf8=2.7.0-20070801+main-2.1 \
-    libmecab-dev=0.996-6 \
-    swig=3.0.12-2 \
+    build-essential=12.9 \
+    curl=7.88.1-10+deb12u12 \
+    file=1:5.44-3 \
+    git=1:2.39.5-0+deb12u2 \
+    default-libmysqlclient-dev=1.1.0 \
+    mecab=0.996-14+b14 \
+    mecab-ipadic-utf8=2.7.0-20070801+main-3 \
+    libmecab-dev=0.996-14+b14 \
+    swig=4.1.0-0.2 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # python-mecab-builder
 
-`Python 3.10` with `mecab` builder dependencies.
+`Python 3.12` with `mecab` builder dependencies.
 
 ## How to use
 - Until 2.0 release, docker images are stored in https://hub.docker.com/r/bebit/python-mecab-builder


### PR DESCRIPTION
# Why
Upgrade python to 3.12 (We would like to upgrade django to 5.2 together with python upgrade)
# What
- Update base image to python 3.12
- Update related dependencies
# When
When releasing python upgrade